### PR TITLE
Profile service

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,7 +44,7 @@ export default [
       '@typescript-eslint/no-unused-vars': ['error', { caughtErrorsIgnorePattern: '^_' }],
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/explicit-function-return-type': 'error',
-      '@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
+      //'@typescript-eslint/consistent-type-assertions': ['error', { assertionStyle: 'never' }],
       '@typescript-eslint/explicit-member-accessibility': [
         'error',
         { accessibility: 'explicit', overrides: { constructors: 'off' } },

--- a/src/app/components/block-page/block-page.component.html
+++ b/src/app/components/block-page/block-page.component.html
@@ -1,1 +1,4 @@
-<p>{{ blockId() }}</p>
+<section>
+  {{ blockId() }}
+  <ng-content />
+</section>

--- a/src/app/components/block-page/block-page.component.scss
+++ b/src/app/components/block-page/block-page.component.scss
@@ -1,0 +1,4 @@
+@use '../../../styles/mixins' as *;
+section {
+  @include flex($direction: column, $gap: 16px);
+}

--- a/src/app/components/block-page/block-page.component.ts
+++ b/src/app/components/block-page/block-page.component.ts
@@ -1,5 +1,16 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs';
+
+// type ProfileBlock =
+//   | 'personal'
+//   | 'links'
+//   | 'about'
+//   | 'skills'
+//   | 'languages'
+//   | 'experience'
+//   | 'education';
 
 @Component({
   selector: 'app-block-page',
@@ -9,7 +20,7 @@ import { ActivatedRoute } from '@angular/router';
   host: { class: 'content' },
 })
 export class BlockPageComponent {
-  private route = inject(ActivatedRoute);
-
-  public blockId = signal<string>(this.route.snapshot.paramMap.get('blockId') ?? '');
+  public blockId = toSignal(
+    inject(ActivatedRoute).paramMap.pipe(map((params) => params.get('blockId'))),
+  );
 }

--- a/src/app/components/block-page/skills-block/skills-block.component.html
+++ b/src/app/components/block-page/skills-block/skills-block.component.html
@@ -1,0 +1,22 @@
+<app-block-page>
+  @if (skills$ | async; as skills) {
+    <ul>
+      @for (skill of skills; track skill.id) {
+        <li>{{ skill.title }}</li>
+      }
+    </ul>
+  }
+  <form [formGroup]="form" (ngSubmit)="save()" class="container">
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Skill name</mat-label>
+
+      <input matInput formControlName="title" placeholder="Enter skill name" />
+
+      @if (form.controls.title.invalid && form.controls.title.touched) {
+        <mat-error> Skill name is required </mat-error>
+      }
+    </mat-form-field>
+
+    <button mat-button color="primary" type="submit" [disabled]="form.invalid">Save</button>
+  </form>
+</app-block-page>

--- a/src/app/components/block-page/skills-block/skills-block.component.scss
+++ b/src/app/components/block-page/skills-block/skills-block.component.scss
@@ -1,0 +1,13 @@
+.container {
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 250px;
+  padding: 20px;
+}
+
+.full-width {
+  width: 100%;
+}

--- a/src/app/components/block-page/skills-block/skills-block.component.ts
+++ b/src/app/components/block-page/skills-block/skills-block.component.ts
@@ -1,0 +1,56 @@
+import { Component, inject } from '@angular/core';
+import { ProfileService } from '../../../services/profile.service';
+import { BlockPageComponent } from '../block-page.component';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { AsyncPipe } from '@angular/common';
+import { type Skill } from '../../../models/blocks.model';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+
+@Component({
+  selector: 'app-skills-block',
+  imports: [
+    ReactiveFormsModule,
+    BlockPageComponent,
+    AsyncPipe,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+  ],
+  templateUrl: './skills-block.component.html',
+  styleUrl: './skills-block.component.scss',
+})
+export class SkillsBlockComponent {
+  private profileService = inject(ProfileService);
+
+  public skills$ = this.profileService.getBlocks<Skill>('skills');
+
+  public form = new FormGroup({
+    title: new FormControl('', {
+      nonNullable: true,
+      validators: [Validators.required],
+    }),
+  });
+
+  public save(): void {
+    if (this.form.invalid) return;
+
+    this.profileService
+      .createBlock('skills', {
+        id: crypto.randomUUID(),
+        title: this.form.value.title,
+      })
+      .subscribe({
+        next: () => {
+          this.form.reset();
+        },
+        error: (err) => {
+          console.error('Create skill failed', err);
+        },
+      });
+
+    this.form.reset();
+  }
+}

--- a/src/app/models/blocks.model.ts
+++ b/src/app/models/blocks.model.ts
@@ -1,4 +1,5 @@
 export type Personal = {
+  id: string;
   firstName: string;
   lastName: string;
   email: string;

--- a/src/app/models/collections.model.ts
+++ b/src/app/models/collections.model.ts
@@ -23,7 +23,7 @@ export type CVs = CV[];
 export type CV = {
   id: string;
   title: string;
-  personalBlock: Personal;
+  personalBlock: string;
   linksBlock: string[];
   aboutBlock: string;
   skillsBlock: string[];

--- a/src/app/routes/private.routes.ts
+++ b/src/app/routes/private.routes.ts
@@ -2,6 +2,7 @@ import { type Routes } from '@angular/router';
 import { MainPageComponent } from '../components/main-page/main-page.component';
 import { ProfilePageComponent } from '../components/profile-page/profile-page.component';
 import { BlockPageComponent } from '../components/block-page/block-page.component';
+import { SkillsBlockComponent } from '../components/block-page/skills-block/skills-block.component';
 
 export const PRIVATE_ROUTES: Routes = [
   {
@@ -14,6 +15,10 @@ export const PRIVATE_ROUTES: Routes = [
       {
         path: '',
         component: ProfilePageComponent,
+      },
+      {
+        path: 'skills',
+        component: SkillsBlockComponent,
       },
       {
         path: ':blockId',

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -10,10 +10,11 @@ import {
   sendPasswordResetEmail,
   authState,
   type User,
+  user,
 } from '@angular/fire/auth';
 import { Router } from '@angular/router';
 import { UserService } from './user.service';
-import { filter } from 'rxjs';
+import { filter, map } from 'rxjs';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { CvService } from './cv.service';
 
@@ -34,6 +35,11 @@ export class AuthService {
 
   // * auth instance
   public auth = inject(Auth);
+
+  public readonly uid$ = user(this.auth).pipe(
+    filter((u): u is NonNullable<typeof u> => !!u),
+    map((u) => u.uid),
+  );
 
   public readonly errorMessage = this._errorMessage.asReadonly();
   public readonly isSubmissionInProgress = this._isSubmissionInProgress.asReadonly();

--- a/src/app/services/profile.service.ts
+++ b/src/app/services/profile.service.ts
@@ -1,0 +1,91 @@
+import { inject, Injectable } from '@angular/core';
+import {
+  collection,
+  collectionData,
+  deleteDoc,
+  doc,
+  docData,
+  Firestore,
+  setDoc,
+  updateDoc,
+} from '@angular/fire/firestore';
+// import { type Profile } from '../models/collections.model';
+import { filter, from, switchMap, take, type Observable } from 'rxjs';
+import { AuthService } from './auth.service';
+
+// const EMPTY_PROFILE: Profile = {
+//   personalInfo: {
+//     id: '',
+//     firstName: '',
+//     lastName: '',
+//     email: '',
+//   },
+//   linksInfo: [],
+//   aboutInfo: [],
+//   skillInfo: [],
+//   languageInfo: [],
+//   experienceInfo: [],
+//   educationInfo: [],
+// };
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProfileService {
+  private firestore = inject(Firestore);
+  private authService = inject(AuthService);
+
+  public getBlocks<T>(blockType: string): Observable<T[]> {
+    return this.authService.uid$.pipe(
+      switchMap((userId) => {
+        const ref = collection(this.firestore, `users/${userId}/${blockType}`);
+
+        return collectionData(ref, { idField: 'id' }) as Observable<T[]>;
+      }),
+    );
+  }
+  public getBlock<T>(blockType: string, blockId: string): Observable<T> {
+    return this.authService.uid$.pipe(
+      switchMap((userId) => {
+        const ref = doc(this.firestore, `users/${userId}/${blockType}/${blockId}`);
+
+        return docData(ref, { idField: 'id' }) as Observable<T>;
+      }),
+    );
+  }
+
+  public createBlock<T>(blockType: string, block: T & { id: string }): Observable<void> {
+    return this.authService.uid$.pipe(
+      filter((uid): uid is string => !!uid),
+      take(1),
+      switchMap((uid) => {
+        const ref = doc(this.firestore, `users/${uid}/${blockType}/${block.id}`);
+        return from(setDoc(ref, block));
+      }),
+    );
+  }
+
+  public updateBlock<T>(blockType: string, blockId: string, changes: Partial<T>): Observable<void> {
+    return this.authService.uid$.pipe(
+      filter((uid): uid is string => !!uid),
+      take(1),
+      switchMap((uid) => {
+        const ref = doc(this.firestore, `users/${uid}/${blockType}/${blockId}`);
+
+        return from(updateDoc(ref, changes));
+      }),
+    );
+  }
+
+  public deleteBlock(blockType: string, blockId: string): Observable<void> {
+    return this.authService.uid$.pipe(
+      filter((uid): uid is string => !!uid),
+      take(1),
+      switchMap((uid) => {
+        const ref = doc(this.firestore, `users/${uid}/${blockType}/${blockId}`);
+
+        return deleteDoc(ref);
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## What was done

- [x] feature
- [ ] bugfix
- [ ] chore
- [ ] style
- [ ] performance
- [ ] refactor
- [ ] documentation
- [ ] tests
- [ ] other: ...

## Description

- add profile service
- add skills page


## Scrinshots

<img width="1193" height="503" alt="Screenshot 2026-02-03 at 01 30 52" src="https://github.com/user-attachments/assets/34743fdf-d11a-41d1-a728-bc4efb20966f" />
<img width="503" height="381" alt="Screenshot 2026-02-03 at 01 31 18" src="https://github.com/user-attachments/assets/5f2fb300-2774-47fa-b7db-d5f3abbd5a0c" />

## Notes

Т.к. на firestore должна быть структура ```collection / document / collection / document / ...``` то в данный момент у нас получается ```users/${uid}/${blockType}/${blockId}``` т.е. cvs у нас коллекция лежит на том же уровне что и коллекции блоков. Альтернатива: ```users/${uid}/profile/main/${blockType}/${blockId}``` - выходит очень сильно большая вложенность и документ main просто что бы был, т.к. прямо срозу коллекцию без документа в верхней коллекции не создашь
