### PR TITLE
Modal

### DIFF
--- a/src/app/components/profile-page/profile-block/profile-block.component.ts
+++ b/src/app/components/profile-page/profile-block/profile-block.component.ts
@@ -12,6 +12,9 @@ import { ProfileBlockItemComponent } from './profile-block-item/profile-block-it
 import { MatButton } from '@angular/material/button';
 import { ProfileService } from '../../../services/profile.service';
 import { type ProfileBlockType } from '../../../models/collections.model';
+import { MatDialog } from '@angular/material/dialog';
+import { DeleteItemComponent } from '../../shared/dialog/delete-item/delete-item.component';
+import { DialogComponent } from '../../shared/dialog/dialog.component';
 
 @Component({
   selector: 'app-profile-block',
@@ -26,11 +29,24 @@ export class ProfileBlockComponent {
   >();
   public blockType = input.required<ProfileBlockType>();
 
-  public removeItem(itemId: string): void {
-    this.profileService.deleteBlock(this.blockType(), itemId).subscribe({
-      error: (err) => {
-        console.error('Delete personal block failed', err);
+  private dialog = inject(MatDialog);
+  public openDialog(itemId: string): void {
+    const ref = this.dialog.open(DialogComponent, {
+      width: '500px',
+      data: {
+        component: DeleteItemComponent,
+        inputs: {
+          itemId: itemId,
+          blockType: this.blockType(),
+        },
       },
     });
+    ref.afterClosed().subscribe((result) => {
+      console.log('Dialog result:', result);
+    });
+  }
+
+  public removeItem(itemId: string): void {
+    this.openDialog(itemId);
   }
 }

--- a/src/app/components/shared/dialog/delete-item/delete-item.component.html
+++ b/src/app/components/shared/dialog/delete-item/delete-item.component.html
@@ -1,0 +1,4 @@
+<h2>Are you sure you want to delete this item?</h2>
+<button mat-stroked-button [disabled]="loading()" (click)="deleteItem()">
+  {{ loading() ? 'Deleting...' : 'Delete Item' }}
+</button>

--- a/src/app/components/shared/dialog/delete-item/delete-item.component.scss
+++ b/src/app/components/shared/dialog/delete-item/delete-item.component.scss
@@ -1,0 +1,6 @@
+@use '../../../../../styles/mixins' as *;
+:host {
+  @include flex($direction: column, $align: center);
+  width: 100%;
+  text-align: center;
+}

--- a/src/app/components/shared/dialog/delete-item/delete-item.component.ts
+++ b/src/app/components/shared/dialog/delete-item/delete-item.component.ts
@@ -1,0 +1,34 @@
+import { Component, inject, input, signal } from '@angular/core';
+import { MatDialogRef } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { MatButton } from '@angular/material/button';
+import { type ProfileBlockType } from '../../../../models/collections.model';
+import { ProfileService } from '../../../../services/profile.service';
+
+@Component({
+  selector: 'app-delete-dashboard',
+  imports: [MatButton],
+  templateUrl: './delete-item.component.html',
+  styleUrl: './delete-item.component.scss',
+})
+export class DeleteItemComponent {
+  public blockType = input.required<ProfileBlockType>();
+  public itemId = input.required<string>();
+  private profileService = inject(ProfileService);
+  private dialogRef = inject(MatDialogRef);
+  private router = inject(Router);
+  public infoMessage = signal('');
+  public hide = signal(true);
+  public loading = signal(false);
+  public deleteItem(): void {
+    this.profileService.deleteBlock(this.blockType(), this.itemId()).subscribe({
+      next: () => {
+        this.dialogRef.close({ saved: true });
+        //his.router.navigate(['/']);
+      },
+      error: (err) => {
+        console.error('Delete item failed', err);
+      },
+    });
+  }
+}

--- a/src/app/components/shared/dialog/dialog.component.html
+++ b/src/app/components/shared/dialog/dialog.component.html
@@ -1,0 +1,7 @@
+<mat-dialog-content>
+  <ng-container *ngComponentOutlet="data.component; inputs: data.inputs" />
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button (click)="close()">Close</button>
+</mat-dialog-actions>

--- a/src/app/components/shared/dialog/dialog.component.scss
+++ b/src/app/components/shared/dialog/dialog.component.scss
@@ -1,0 +1,4 @@
+mat-dialog-content {
+  height: auto;
+  overflow: hidden;
+}

--- a/src/app/components/shared/dialog/dialog.component.ts
+++ b/src/app/components/shared/dialog/dialog.component.ts
@@ -1,0 +1,31 @@
+import { type ComponentType } from '@angular/cdk/overlay';
+import { NgComponentOutlet } from '@angular/common';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogContent,
+  MatDialogRef,
+} from '@angular/material/dialog';
+
+export type DialogData<T = unknown> = {
+  component: ComponentType<T>;
+  inputs?: Partial<T>;
+};
+
+@Component({
+  selector: 'app-dialog',
+  imports: [NgComponentOutlet, MatButtonModule, MatDialogActions, MatDialogContent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './dialog.component.html',
+  styleUrl: './dialog.component.scss',
+})
+export class DialogComponent {
+  private dialogRef = inject(MatDialogRef<DialogComponent>);
+  public readonly data = inject<DialogData>(MAT_DIALOG_DATA);
+
+  public close(): void {
+    this.dialogRef.close();
+  }
+}


### PR DESCRIPTION
## What was done

- [x] feature
- [ ] bugfix
- [ ] chore
- [ ] style
- [ ] performance
- [ ] refactor
- [ ] documentation
- [ ] tests
- [ ] other: ...

## Description

- add reusable dialog

## Screenshots

<img width="624" height="323" alt="Screenshot 2026-02-09 at 10 09 17" src="https://github.com/user-attachments/assets/9c0b6bf5-7b6c-4a84-9b8e-d39201e489a3" />

## Notes

как использовать:

- создаем компонент который будем прокидывать в модалку, который может принимать инпуты если нужно (пример ```components/shared/dialog/delete-item```

- далее в компоненте из которого должно открываться модальное окно 
```
private dialog = inject(MatDialog);
  public openDialog(itemId: string): void {
    const ref = this.dialog.open(DialogComponent, {
      width: '500px',
      data: {
        component: DeleteItemComponent,
        inputs: {
          itemId: itemId,
          blockType: this.blockType(),
        },
      },
    });
    ref.afterClosed().subscribe((result) => {
      console.log('Dialog result:', result);
    });
  }

  public removeItem(itemId: string): void {
    this.openDialog(itemId);
  }
  ```
  где в ```data``` передаем компонет который хотим пробросить и инпуты (если требуется) для него
